### PR TITLE
Further CI fixes

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,9 +15,10 @@ permissions:
   contents: write
   pull-requests: write
 
+# Only cancel in-progress runs of the same PR, never cancel production deployment
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   deploy:
@@ -92,8 +93,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
           destination_dir: ${{ env.PUBLISH_DIR }}
-          remove_files: true
-          keep_files: true
+          keep_files: false
 
       # Comment on PR with preview URL
       - name: Comment on PR

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
This PR introduces some fixes in the CI/CD pipeline, where a deprecated version of the Ubuntu runner was used, and release builds were being cancelled by builds triggered when a PR is closed. It also fixes one faulty property in the 'Remove PR preview' step.